### PR TITLE
Randomize UDP src port used in GTPU encapsulation

### DIFF
--- a/src/gtpu.cpp
+++ b/src/gtpu.cpp
@@ -40,6 +40,8 @@ int GTPU::Encap(struct rte_mbuf *pkt)
 	rte_ether_addr_copy(&eth->d_addr, &new_eth->d_addr);
 
     // Set the outer headers
+    uint32_t random_src_port = rand() % 10000;
+    m_rewrite.udp.src_port = htons(random_src_port);
     ip4_gtpu_header_t * ip4_gtpu = (ip4_gtpu_header_t *)(new_eth + 1);
     memcpy(ip4_gtpu, &m_rewrite, sizeof(ip4_gtpu_header_t));
 

--- a/src/gtpu.cpp
+++ b/src/gtpu.cpp
@@ -40,7 +40,8 @@ int GTPU::Encap(struct rte_mbuf *pkt)
 	rte_ether_addr_copy(&eth->d_addr, &new_eth->d_addr);
 
     // Set the outer headers
-    uint32_t random_src_port = rand() % 10000;
+    const uint32_t mask = (2<<16) -1;
+    uint32_t random_src_port = it->second.steid & mask;
     m_rewrite.udp.src_port = htons(random_src_port);
     ip4_gtpu_header_t * ip4_gtpu = (ip4_gtpu_header_t *)(new_eth + 1);
     memcpy(ip4_gtpu, &m_rewrite, sizeof(ip4_gtpu_header_t));

--- a/src/gtpu.cpp
+++ b/src/gtpu.cpp
@@ -143,6 +143,7 @@ void GTPU::Prepare()
     m_rewrite.ip4.src_addr = htonl(m_src_addr);
     m_rewrite.ip4.dst_addr = htonl(m_dst_addr);
 
+    // Source port will later be randomized during encapsulation
     m_rewrite.udp.src_port = htons(GTPU_UDP_PORT);
     m_rewrite.udp.dst_port = htons(GTPU_UDP_PORT);
 


### PR DESCRIPTION
Currently all GTPU packets are encapsulated in UDP packets with a fixed src and dest port (2152). In a real deployment, we can't assume that the src port will be fixed, not even for each tunnel. As a result, all packets (from any tunnel) from a trex interface will be picked up by the same worker thread on the target, making it hard to benchmark logic that involves concurrency.

This PR picks a pseudo random UDP src port, based on the source teid (which is AFAIK is generated at random).
Disclaimer: This comes with a small performance degradation on the maximum rate at which trex can generate packets (see attached).
[trex-benchmark.zip](https://github.com/EMnify/trex-core/files/6309282/trex-benchmark.zip)

